### PR TITLE
Don't remove instance of message from response

### DIFF
--- a/jakartaee-microprofile-example/src/main/java/dev/langchain4j/example/chat/ChatAgent.java
+++ b/jakartaee-microprofile-example/src/main/java/dev/langchain4j/example/chat/ChatAgent.java
@@ -40,9 +40,7 @@ public class ChatAgent {
     }
 
     public String chat(String sessionId, String message) throws Exception {
-        String reply = getAssistant().chat(sessionId, message).trim();
-        int i = reply.lastIndexOf(message);
-        return i > 0 ? reply.substring(i) : reply;
+        return getAssistant().chat(sessionId, message).trim();
     }
 
 }


### PR DESCRIPTION
For example, type just "e" into the chat. You'll likely get a cut off response from the agent.